### PR TITLE
Patched zone creations

### DIFF
--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -424,7 +424,7 @@ class FOSRestExtension extends Extension implements PrependExtensionInterface
         }
 
         $container
-            ->register($id, new DefinitionDecorator('fos_rest.zone_request_matcher'))
+            ->setDefinition($id, new DefinitionDecorator('fos_rest.zone_request_matcher'))
             ->setArguments($arguments)
         ;
 

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -646,14 +646,14 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('addRequestMatcher', $addRequestMatcherCalls[0][0]);
         $requestMatcherFirstId = (string) $addRequestMatcherCalls[0][1][0];
         $requestMatcherFirst = $this->container->getDefinition($requestMatcherFirstId);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', get_class($requestMatcherFirst));
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $requestMatcherFirst);
         $this->assertEquals('/api/*', $requestMatcherFirst->getArgument(0));
 
         // Second zone
         $this->assertEquals('addRequestMatcher', $addRequestMatcherCalls[1][0]);
         $requestMatcherSecondId = (string) $addRequestMatcherCalls[1][1][0];
         $requestMatcherSecond = $this->container->getDefinition($requestMatcherSecondId);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', get_class($requestMatcherSecond));
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $requestMatcherSecond);
         $this->assertEquals('/^second', $requestMatcherSecond->getArgument(0));
         $this->assertEquals(array('127.0.0.1'), $requestMatcherSecond->getArgument(3));
     }

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -646,14 +646,14 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('addRequestMatcher', $addRequestMatcherCalls[0][0]);
         $requestMatcherFirstId = (string) $addRequestMatcherCalls[0][1][0];
         $requestMatcherFirst = $this->container->getDefinition($requestMatcherFirstId);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $requestMatcherFirst->getClass());
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', get_class($requestMatcherFirst));
         $this->assertEquals('/api/*', $requestMatcherFirst->getArgument(0));
 
         // Second zone
         $this->assertEquals('addRequestMatcher', $addRequestMatcherCalls[1][0]);
         $requestMatcherSecondId = (string) $addRequestMatcherCalls[1][1][0];
         $requestMatcherSecond = $this->container->getDefinition($requestMatcherSecondId);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $requestMatcherSecond->getClass());
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', get_class($requestMatcherSecond));
         $this->assertEquals('/^second', $requestMatcherSecond->getArgument(0));
         $this->assertEquals(array('127.0.0.1'), $requestMatcherSecond->getArgument(3));
     }


### PR DESCRIPTION
I was having this problems to generate de cache using one zone:
Warning: substr() expects parameter 1 to be string, object given

With --no-debug:
PHP Warning:  strpos() expects parameter 1 to be string, object given in /home/r00t/Workspace/corporapp/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php on line 563
PHP Warning:  ltrim() expects parameter 1 to be string, object given in /home/r00t/Workspace/corporapp/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php on line 563
PHP Warning:  ltrim() expects parameter 1 to be string, object given in /home/r00t/Workspace/corporapp/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php on line 563
PHP Warning:  substr() expects parameter 1 to be string, object given in /home/r00t/Workspace/corporapp/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php on line 371

The service is already registered, we only want to add new definitions of the service with different arguments.
